### PR TITLE
Windows support

### DIFF
--- a/naxsi_src/config
+++ b/naxsi_src/config
@@ -9,6 +9,14 @@ naxsi_includes="
     $ngx_addon_dir/naxsi_net.h \
 "
 
+# prepend ngx_config.h to libinjection sources, copy headers
+mkdir -p $ngx_addon_dir/libinjection/ngxbuild
+cp $ngx_addon_dir/libinjection/src/*.h $ngx_addon_dir/libinjection/ngxbuild/
+for src_file in libinjection_html5.c libinjection_sqli.c libinjection_xss.c ; do
+    echo "#include <ngx_config.h>" > $ngx_addon_dir/libinjection/ngxbuild/$src_file
+    cat $ngx_addon_dir/libinjection/src/$src_file >> $ngx_addon_dir/libinjection/ngxbuild/$src_file
+done;
+
 # NAXSI C source files
 naxsi_sources="
     $ngx_addon_dir/naxsi_config.c \
@@ -19,9 +27,10 @@ naxsi_sources="
     $ngx_addon_dir/naxsi_skeleton.c \
     $ngx_addon_dir/naxsi_utf8.c \
     $ngx_addon_dir/naxsi_utils.c \
-    $ngx_addon_dir/libinjection/src/libinjection_html5.c \
-    $ngx_addon_dir/libinjection/src/libinjection_sqli.c \
-    $ngx_addon_dir/libinjection/src/libinjection_xss.c \
+    $ngx_addon_dir/naxsi_windows.c \
+    $ngx_addon_dir/libinjection/ngxbuild/libinjection_html5.c \
+    $ngx_addon_dir/libinjection/ngxbuild/libinjection_sqli.c \
+    $ngx_addon_dir/libinjection/ngxbuild/libinjection_xss.c \
 "
 
 # NGINX module condfiguration.

--- a/naxsi_src/naxsi.h
+++ b/naxsi_src/naxsi.h
@@ -18,6 +18,13 @@
 #include "libinjection/src/libinjection_sqli.h"
 #include "libinjection/src/libinjection_xss.h"
 
+#ifdef _WIN32
+#include "naxsi_windows.h"
+
+#pragma warning(disable:4214)
+
+#endif // _WIN32
+
 extern ngx_module_t ngx_http_naxsi_module;
 
 /**

--- a/naxsi_src/naxsi_config.c
+++ b/naxsi_src/naxsi_config.c
@@ -1,9 +1,22 @@
 // SPDX-FileCopyrightText: 2016-2019, Thibault 'bui' Koechlin <tko@nbs-system.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 #include <naxsi_config.h>
 #include <naxsi_macros.h>
+
+#ifdef _WIN32
+#pragma warning(disable:4214)
+#pragma warning(disable:4204)
+#pragma warning(disable:4221)
+#pragma warning(disable:4456)
+#pragma warning(disable:4702)
+#pragma warning(disable:4701)
+#pragma warning(disable:4706)
+#endif // _WIN32
+
 /*
 ** TOP LEVEL configuration parsing code
 */

--- a/naxsi_src/naxsi_json.c
+++ b/naxsi_src/naxsi_json.c
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2016-2019, Thibault 'bui' Koechlin <tko@nbs-system.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 #include <naxsi_macros.h>
 

--- a/naxsi_src/naxsi_net.c
+++ b/naxsi_src/naxsi_net.c
@@ -1,8 +1,14 @@
 // SPDX-FileCopyrightText: 2019, Giovanni Dante Grazioli <gda@nbs-system.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 #include <naxsi_net.h>
+
+#ifdef _WIN32
+#pragma warning(disable:4702)
+#endif // _WIN32
 
 int
 parse_ipv6(const char* addr, ip_t* ip, char* ip_str)

--- a/naxsi_src/naxsi_net.h
+++ b/naxsi_src/naxsi_net.h
@@ -12,7 +12,11 @@
 #include <sys/types.h>
 #endif
 
+#ifndef _WIN32
 #include <arpa/inet.h>
+#else
+#include <winsock2.h>
+#endif // !_WIN32
 #include <stdint.h>
 #include <string.h>
 

--- a/naxsi_src/naxsi_raw.c
+++ b/naxsi_src/naxsi_raw.c
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2016-2019, Thibault 'bui' Koechlin <tko@nbs-system.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 
 void

--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -1,9 +1,19 @@
 // SPDX-FileCopyrightText: 2016-2019, Thibault 'bui' Koechlin <tko@nbs-system.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 #include <naxsi_macros.h>
 #include <naxsi_net.h>
+
+#ifdef _WIN32
+#pragma warning(disable:4204)
+#pragma warning(disable:4221)
+#pragma warning(disable:4456)
+#pragma warning(disable:4701)
+#pragma warning(disable:4702)
+#endif // _WIN32
 
 /* used to store locations during the configuration time.
    then, accessed by the hashtable building feature during "init" time. */

--- a/naxsi_src/naxsi_skeleton.c
+++ b/naxsi_src/naxsi_skeleton.c
@@ -7,12 +7,24 @@
 ** aware of nginx's modules can skip most of this.
 */
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 #include <naxsi_net.h>
 
 #include <ctype.h>
+
+#ifndef _WIN32
 #include <strings.h>
 #include <sys/times.h>
+#else
+#include <process.h>
+#endif // !_WIN32
+
+#ifdef _WIN32
+#pragma warning(disable:4204)
+#pragma warning(disable:4996)
+#endif // _WIN32
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 

--- a/naxsi_src/naxsi_utf8.c
+++ b/naxsi_src/naxsi_utf8.c
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 1999 Markus Kuhn <mgk25@cl.cam.ac.uk>
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 
 /* @file naxsi_utf8.c

--- a/naxsi_src/naxsi_utils.c
+++ b/naxsi_src/naxsi_utils.c
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2016-2019, Thibault 'bui' Koechlin <tko@nbs-system.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <ngx_config.h>
+
 #include <naxsi.h>
 #include <naxsi_net.h>
 

--- a/naxsi_src/naxsi_windows.c
+++ b/naxsi_src/naxsi_windows.c
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2022, Alex <alex@staticlibs.net>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <ngx_config.h>
+
+#ifdef _WIN32
+#include "naxsi_windows.h"
+
+int gettimeofday(struct timeval *t,void *timezone)
+{       
+  struct _timeb timebuffer;
+  _ftime(&timebuffer);
+  t->tv_sec=timebuffer.time;
+  t->tv_usec=1000*timebuffer.millitm;
+  return 0;
+}
+
+clock_t times(struct tms *__buffer)
+{
+	__buffer->tms_utime = clock();
+	__buffer->tms_stime = 0;
+	__buffer->tms_cstime = 0;
+	__buffer->tms_cutime = 0;
+	return __buffer->tms_utime;
+}
+
+int inet_pton(int af, const char *src, void *dst)
+{
+  struct sockaddr_storage ss;
+  int size = sizeof(ss);
+  char src_copy[INET6_ADDRSTRLEN+1];
+
+  ZeroMemory(&ss, sizeof(ss));
+  /* stupid non-const API */
+  strncpy (src_copy, src, INET6_ADDRSTRLEN+1);
+  src_copy[INET6_ADDRSTRLEN] = 0;
+
+  if (WSAStringToAddress(src_copy, af, NULL, (struct sockaddr *)&ss, &size) == 0) {
+    switch(af) {
+      case AF_INET:
+    *(struct in_addr *)dst = ((struct sockaddr_in *)&ss)->sin_addr;
+    return 1;
+      case AF_INET6:
+    *(struct in6_addr *)dst = ((struct sockaddr_in6 *)&ss)->sin6_addr;
+    return 1;
+    }
+  }
+  return 0;
+}
+
+const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
+{
+  struct sockaddr_storage ss;
+  unsigned long s = size;
+
+  ZeroMemory(&ss, sizeof(ss));
+  ss.ss_family = af;
+
+  switch(af) {
+    case AF_INET:
+      ((struct sockaddr_in *)&ss)->sin_addr = *(struct in_addr *)src;
+      break;
+    case AF_INET6:
+      ((struct sockaddr_in6 *)&ss)->sin6_addr = *(struct in6_addr *)src;
+      break;
+    default:
+      return NULL;
+  }
+  /* cannot direclty use &size because of strict aliasing rules */
+  return (WSAAddressToString((struct sockaddr *)&ss, sizeof(ss), NULL, dst, &s) == 0)?
+          dst : NULL;
+}
+
+#endif // _WIN32

--- a/naxsi_src/naxsi_windows.h
+++ b/naxsi_src/naxsi_windows.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2022, Alex <alex@staticlibs.net>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef __NAXSI_WINDOWS_H__
+#define __NAXSI_WINDOWS_H__
+
+#include <sys/timeb.h>
+#include <sys/types.h>
+#include <winsock2.h>
+
+int gettimeofday(struct timeval* t,void* timezone);
+
+// from linux's sys/times.h
+
+//#include <features.h>
+
+#define __need_clock_t
+#include <time.h>
+
+#define uint ngx_uint_t
+#define random rand
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#define srandom srand
+#define getpid _getpid
+
+// From http://www.linuxjournal.com/article/5574
+
+/* Structure describing CPU time used by a process and its children.  */
+struct tms
+{
+  clock_t tms_utime;          /* User CPU time.  */
+  clock_t tms_stime;          /* System CPU time.  */
+
+  clock_t tms_cutime;         /* User CPU time of dead children.  */
+  clock_t tms_cstime;         /* System CPU time of dead children.  */
+};
+
+/* Store the CPU time used by this process and all its
+   dead children (and their dead children) in BUFFER.
+   Return the elapsed real time, or (clock_t) -1 for errors.
+   All times are in CLK_TCKths of a second.  */
+clock_t times(struct tms *__buffer);
+
+typedef long long suseconds_t ;
+
+
+// From https://stackoverflow.com/a/20816961
+
+int inet_pton(int af, const char *src, void *dst);
+
+const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
+
+#endif // __NAXSI_WINDOWS_H__


### PR DESCRIPTION
Hi, I've got a requirement to add a WAF to a Nginx installation, and this Nginx installation runs on Windows (don't ask why :) ). Windows build of NAXSI appeared to be relatively straightforward. The `<ngx_config.h>` is required on top of every `.c` file due to the way how Nginx uses precompiled headers with MSVC. Other changes are typical Windows porting stuff.

This PR should not break Linux, I've checked that Linux build still works and basic rules can be loaded with it.

Note, some of the disabled MSVC warnings are just noise, but some (like unreachable code) seems to point to actual (minor) problems. I intentionally did not touch the code that causes the warnings, intent to revisit these warnings one by one.

For building it on Windows I use [this setup](https://github.com/noproxy-http/nginx-windows), the latest 1.22.0-3 CI build there includes NAXSI and passes a smoke testing with default rules.

Please let me know if Windows PRs to NAXSI can be accepted in principle.

Thanks for keeping this nice project alive!