### PR TITLE
Windows CI build support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,22 @@
+name: "Windows CI Build"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: cmd
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        persist-credentials: false
+    - name: Windows build
+      run: .scripts\ci-windows.bat

--- a/.scripts/ci-windows.bat
+++ b/.scripts/ci-windows.bat
@@ -1,0 +1,16 @@
+@echo off
+rem SPDX-FileCopyrightText: 2022 Alex <alex@staticlibs.net>
+rem SPDX-License-Identifier: LGPL-3.0-only
+
+@echo on
+
+set BAD_SLASH_SCRIPT_DIR=%~dp0
+set SCRIPT_DIR=%BAD_SLASH_SCRIPT_DIR:\=/%
+set NAXSI_DIR=%SCRIPT_DIR%..
+
+cd ..
+git clone https://github.com/noproxy-http/nginx-windows.git
+cd nginx-windows
+git submodule update --init
+robocopy %NAXSI_DIR%/naxsi_src modules/naxsi_src /e /nfl /ndl /njh /njs /nc /ns /np
+scripts\build.bat


### PR DESCRIPTION
Hi, this patch adds a GH workflow that builds Nginx with Naxsi included on Windows. It is understood, that without dynamic modules support and currently without test runs, Windows CI build is not very useful. Still it probably won't harm and, in theory, additional possible warnings from MSVC compiler may be useful for future code changes.