### PR TITLE
Windows CI enhancements

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        nginx:
+          - 1.23.2
+          - 1.22.1
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: cmd
@@ -19,4 +26,4 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Windows build
-      run: .scripts\ci-windows.bat
+      run: .scripts\ci-windows.bat ${{ matrix.nginx }}

--- a/.scripts/ci-windows.bat
+++ b/.scripts/ci-windows.bat
@@ -7,10 +7,24 @@ rem SPDX-License-Identifier: LGPL-3.0-only
 set BAD_SLASH_SCRIPT_DIR=%~dp0
 set SCRIPT_DIR=%BAD_SLASH_SCRIPT_DIR:\=/%
 set NAXSI_DIR=%SCRIPT_DIR%..
+set NW_DIR=%NAXSI_DIR%/../nginx-windows
 
-cd ..
-git clone https://github.com/noproxy-http/nginx-windows.git
-cd nginx-windows
-git submodule update --init
-robocopy %NAXSI_DIR%/naxsi_src modules/naxsi_src /e /nfl /ndl /njh /njs /nc /ns /np
-scripts\build.bat
+set NGINX_VERSION=%1
+
+pushd .. || exit /b 1
+git clone --branch 1.22.1-1 https://github.com/noproxy-http/nginx-windows.git || exit /b 1
+popd || exit /b 1
+
+pushd "%NW_DIR%" || exit /b 1
+git submodule update --init || exit /b 1
+popd || exit /b 1
+
+pushd "%NW_DIR%/sources/nginx" || exit /b 1
+git checkout release-%NGINX_VERSION% || exit /b 1
+popd || exit /b 1
+
+robocopy %NAXSI_DIR%/naxsi_src %NW_DIR%/modules/naxsi_src /e /nfl /ndl /njh /njs /nc /ns /np
+
+pushd "%NW_DIR%" || exit /b 1
+scripts\build.bat "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat" nossl
+popd || exit /b 1


### PR DESCRIPTION
This patch adds the following enhancements to Windows CI builds:

1. builds are done without OpenSSL, so the full build now takes about 3 minutes
2. Nginx version matrix is added, currently `1.22.1` and `1.23.2` are included there; older version may require additional configuration due to PCRE2 used by default (PCRE1 is present in build env, just the configure script defaults to PCRE2) 