### PR TITLE
Add libinjection modified sources to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ nginx-source
 nginx-tmp
 *.log
 .scripts/.tmp/
+/naxsi_src/libinjection_ngxbuild/

--- a/naxsi_src/config
+++ b/naxsi_src/config
@@ -10,11 +10,11 @@ naxsi_includes="
 "
 
 # prepend ngx_config.h to libinjection sources, copy headers
-mkdir -p $ngx_addon_dir/libinjection/ngxbuild
-cp $ngx_addon_dir/libinjection/src/*.h $ngx_addon_dir/libinjection/ngxbuild/
+mkdir -p $ngx_addon_dir/libinjection_ngxbuild
+cp $ngx_addon_dir/libinjection/src/*.h $ngx_addon_dir/libinjection_ngxbuild/
 for src_file in libinjection_html5.c libinjection_sqli.c libinjection_xss.c ; do
-    echo "#include <ngx_config.h>" > $ngx_addon_dir/libinjection/ngxbuild/$src_file
-    cat $ngx_addon_dir/libinjection/src/$src_file >> $ngx_addon_dir/libinjection/ngxbuild/$src_file
+    echo "#include <ngx_config.h>" > $ngx_addon_dir/libinjection_ngxbuild/$src_file
+    cat $ngx_addon_dir/libinjection/src/$src_file >> $ngx_addon_dir/libinjection_ngxbuild/$src_file
 done;
 
 # NAXSI C source files
@@ -28,9 +28,9 @@ naxsi_sources="
     $ngx_addon_dir/naxsi_utf8.c \
     $ngx_addon_dir/naxsi_utils.c \
     $ngx_addon_dir/naxsi_windows.c \
-    $ngx_addon_dir/libinjection/ngxbuild/libinjection_html5.c \
-    $ngx_addon_dir/libinjection/ngxbuild/libinjection_sqli.c \
-    $ngx_addon_dir/libinjection/ngxbuild/libinjection_xss.c \
+    $ngx_addon_dir/libinjection_ngxbuild/libinjection_html5.c \
+    $ngx_addon_dir/libinjection_ngxbuild/libinjection_sqli.c \
+    $ngx_addon_dir/libinjection_ngxbuild/libinjection_xss.c \
 "
 
 # NGINX module condfiguration.


### PR DESCRIPTION
libinjection `.c` files need to be prepended with `#include <ngx_config.h>` for Windows builds to work. Initial Windows support copies libinjection files into `libinjection/ngxbuild`. It causes the `git status` to show "Untracked content" in libinjection submodule dir after the build.

This change leaves the copy/prepend logic exactly the same, just changes the path from `libinjection/ngxbuild` to `libinjection_ngxbuild` (to keep it outside of submodule) and adds this path to `.gitignore`.

If desired, this copy/prepend logic can be made Windows-only adding the OS checks in `naxsi_src/config` script, currently logic is exactly the same for Windows and Linux builds. 