### PR TITLE
Windows warnings cleanup

### DIFF
--- a/naxsi_src/naxsi.h
+++ b/naxsi_src/naxsi.h
@@ -20,9 +20,6 @@
 
 #ifdef _WIN32
 #include "naxsi_windows.h"
-
-#pragma warning(disable:4214)
-
 #endif // _WIN32
 
 extern ngx_module_t ngx_http_naxsi_module;

--- a/naxsi_src/naxsi_config.c
+++ b/naxsi_src/naxsi_config.c
@@ -7,16 +7,6 @@
 #include <naxsi_config.h>
 #include <naxsi_macros.h>
 
-#ifdef _WIN32
-#pragma warning(disable:4214)
-#pragma warning(disable:4204)
-#pragma warning(disable:4221)
-#pragma warning(disable:4456)
-#pragma warning(disable:4702)
-#pragma warning(disable:4701)
-#pragma warning(disable:4706)
-#endif // _WIN32
-
 /*
 ** TOP LEVEL configuration parsing code
 */
@@ -114,15 +104,15 @@ naxsi_score(ngx_conf_t* r, ngx_str_t* tmp, ngx_http_rule_t* rule)
       NX_LOG_DEBUG(
         _debug_score, NGX_LOG_EMERG, r, 0, "XX-(debug) special scoring rule (%s)", tmp_ptr);
 
-      return_value_if(!(tmp_end = strchr(tmp_ptr, ':')), NGX_CONF_ERROR);
+      return_value_if(NULL == (tmp_end = strchr(tmp_ptr, ':')), NGX_CONF_ERROR);
 
       return_value_if((len = tmp_end - tmp_ptr) < 1, NGX_CONF_ERROR);
 
-      return_value_if(!(sc = ngx_array_push(rule->sscores)), NGX_CONF_ERROR);
+      return_value_if(NULL == (sc = ngx_array_push(rule->sscores)), NGX_CONF_ERROR);
 
-      return_value_if(!(sc->sc_tag = ngx_pcalloc(r->pool, sizeof(ngx_str_t))), NGX_CONF_ERROR);
+      return_value_if(NULL == (sc->sc_tag = ngx_pcalloc(r->pool, sizeof(ngx_str_t))), NGX_CONF_ERROR);
 
-      return_value_if(!(sc->sc_tag->data = ngx_pcalloc(r->pool, len + 1)), NGX_CONF_ERROR);
+      return_value_if(NULL == (sc->sc_tag->data = ngx_pcalloc(r->pool, len + 1)), NGX_CONF_ERROR);
 
       memcpy(sc->sc_tag->data, tmp_ptr, len);
       sc->sc_tag->len = len;
@@ -257,7 +247,7 @@ naxsi_zone(ngx_conf_t* r, ngx_str_t* tmp, ngx_http_rule_t* rule)
         return_value_if(!rule->br->custom_locations, NGX_CONF_ERROR);
       }
 
-      return_value_if(!(custom_rule = ngx_array_push(rule->br->custom_locations)), NGX_CONF_ERROR);
+      return_value_if(NULL == (custom_rule = ngx_array_push(rule->br->custom_locations)), NGX_CONF_ERROR);
 
       memset(custom_rule, 0, sizeof(ngx_http_custom_rule_location_t));
       if (!strncmp(tmp_ptr, MZ_GET_VAR_T, strlen(MZ_GET_VAR_T))) {
@@ -374,13 +364,13 @@ void*
 naxsi_str(ngx_conf_t* r, ngx_str_t* tmp, ngx_http_rule_t* rule)
 {
   ngx_str_t* str;
-  uint       i;
+  ngx_uint_t   i;
 
   return_value_if(!rule->br, NGX_CONF_ERROR);
 
   rule->br->match_type = STR;
 
-  return_value_if(!(str = ngx_pcalloc(r->pool, sizeof(ngx_str_t))), NGX_CONF_ERROR);
+  return_value_if(NULL == (str = ngx_pcalloc(r->pool, sizeof(ngx_str_t))), NGX_CONF_ERROR);
 
   str->data = tmp->data + strlen(STR_T);
   str->len  = tmp->len - strlen(STR_T);

--- a/naxsi_src/naxsi_net.c
+++ b/naxsi_src/naxsi_net.c
@@ -6,10 +6,6 @@
 #include <naxsi.h>
 #include <naxsi_net.h>
 
-#ifdef _WIN32
-#pragma warning(disable:4702)
-#endif // _WIN32
-
 int
 parse_ipv6(const char* addr, ip_t* ip, char* ip_str)
 {
@@ -76,5 +72,4 @@ is_in_subnet(const cidr_t* cidr, const ip_t* ip, int is_ipv6)
     return (ip->v6[0] & cidr->mask.v6[0]) == (cidr->subnet.v6[0] & cidr->mask.v6[0]) &&
            (ip->v6[1] & cidr->mask.v6[1]) == (cidr->subnet.v6[1] & cidr->mask.v6[1]);
   }
-  return 0;
 }

--- a/naxsi_src/naxsi_net.c
+++ b/naxsi_src/naxsi_net.c
@@ -66,10 +66,11 @@ is_in_subnet(const cidr_t* cidr, const ip_t* ip, int is_ipv6)
   if ((cidr->version == IPv6 && !is_ipv6) || (cidr->version == IPv4 && is_ipv6)) {
     return 0;
   }
+
   if (cidr->version == IPv4) {
     return (ip->v4 & cidr->mask.v4) == (cidr->subnet.v4 & cidr->mask.v4);
-  } else {
-    return (ip->v6[0] & cidr->mask.v6[0]) == (cidr->subnet.v6[0] & cidr->mask.v6[0]) &&
-           (ip->v6[1] & cidr->mask.v6[1]) == (cidr->subnet.v6[1] & cidr->mask.v6[1]);
   }
+
+  return (ip->v6[0] & cidr->mask.v6[0]) == (cidr->subnet.v6[0] & cidr->mask.v6[0]) &&
+          (ip->v6[1] & cidr->mask.v6[1]) == (cidr->subnet.v6[1] & cidr->mask.v6[1]);
 }

--- a/naxsi_src/naxsi_skeleton.c
+++ b/naxsi_src/naxsi_skeleton.c
@@ -21,11 +21,6 @@
 #include <process.h>
 #endif // !_WIN32
 
-#ifdef _WIN32
-#pragma warning(disable:4204)
-#pragma warning(disable:4996)
-#endif // _WIN32
-
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 /*
@@ -594,7 +589,11 @@ ngx_http_naxsi_init(ngx_conf_t* cf)
   }
 
   /* initialize prng (used for fragmented logs) */
+#ifndef _WIN32
   srandom(time(0) * getpid());
+#else // _WIN32
+  srand(time(0) * _getpid());
+#endif // !_WIN32
 
   /*
   ** initalise internal rules for libinjection sqli/xss

--- a/naxsi_src/naxsi_utils.c
+++ b/naxsi_src/naxsi_utils.c
@@ -235,7 +235,7 @@ ngx_http_wlr_push_disabled(ngx_conf_t* cf, ngx_http_naxsi_loc_conf_t* dlc, ngx_h
 static ngx_int_t
 ngx_http_wlr_merge(ngx_conf_t* cf, ngx_http_whitelist_rule_t* father_wl, ngx_http_rule_t* curr)
 {
-  uint       i;
+  ngx_uint_t i;
   ngx_int_t* tmp_ptr;
 
   NX_LOG_DEBUG(_debug_whitelist, NGX_LOG_EMERG, cf, 0, "[naxsi] merging similar wl(s)");
@@ -268,7 +268,7 @@ ngx_http_wlr_identify(ngx_conf_t*                cf,
                       int*                       name_idx)
 {
 
-  uint i;
+  ngx_uint_t i;
 
   /*
     identify global match zones (|ARGS|BODY|HEADERS|URL|FILE_EXT)
@@ -369,7 +369,7 @@ ngx_http_wlr_find(ngx_conf_t*                cf,
                   int                        name_idx,
                   char**                     fullname)
 {
-  uint i;
+  ngx_uint_t i;
 
   /* Create unique string for rule, and try to find it in existing rules.*/
   /*name AND uri*/
@@ -432,7 +432,7 @@ ngx_http_wlr_find(ngx_conf_t*                cf,
   for (i = 0; i < dlc->tmp_wlr->nelts; i++)
     if (!strcmp((const char*)*fullname,
                 (const char*)((ngx_http_whitelist_rule_t*)dlc->tmp_wlr->elts)[i].name->data) &&
-        ((ngx_http_whitelist_rule_t*)dlc->tmp_wlr->elts)[i].zone == (uint)zone) {
+        ((ngx_http_whitelist_rule_t*)dlc->tmp_wlr->elts)[i].zone == (ngx_uint_t)zone) {
       NX_LOG_DEBUG(_debug_whitelist_heavy,
                    NGX_LOG_EMERG,
                    cf,
@@ -452,7 +452,7 @@ ngx_http_wlr_finalize_hashtables(ngx_conf_t* cf, ngx_http_naxsi_loc_conf_t* dlc)
   ngx_array_t *   get_ar = NULL, *headers_ar = NULL, *body_ar = NULL, *uri_ar = NULL;
   ngx_hash_key_t* arr_node;
   ngx_hash_init_t hash_init;
-  uint            i;
+  ngx_uint_t      i;
 
   NX_LOG_DEBUG(_debug_whitelist_heavy, NGX_LOG_EMERG, cf, 0, "finalizing hashtables");
 
@@ -664,7 +664,7 @@ ngx_http_naxsi_create_hashtables_n(ngx_http_naxsi_loc_conf_t* dlc, ngx_conf_t* c
   ngx_http_rule_t**          rptr;
   ngx_regex_compile_t*       rgc;
   char*                      fullname;
-  uint                       i;
+  ngx_uint_t                 i;
 
   if (!dlc->whitelist_rules || dlc->whitelist_rules->nelts < 1) {
     NX_LOG_DEBUG(

--- a/naxsi_src/naxsi_windows.h
+++ b/naxsi_src/naxsi_windows.h
@@ -18,12 +18,8 @@ gettimeofday(struct timeval* t, void* timezone);
 #define __need_clock_t
 #include <time.h>
 
-#define uint        ngx_uint_t
-#define random      rand
 #define strncasecmp _strnicmp
 #define strcasecmp  _stricmp
-#define srandom     srand
-#define getpid      _getpid
 
 // From http://www.linuxjournal.com/article/5574
 


### PR DESCRIPTION
This patch cleans up the Windows-specific warnings. All `pragma warning`s and most of Windows defines are removed. Actual code changes are minor and expected to be harmless (just please take a look, if `return_value_if` usage is still correct). 