### PR TITLE
Fix response body read in test HTTP client

### DIFF
--- a/unit-tests/python/_test_utils.py
+++ b/unit-tests/python/_test_utils.py
@@ -172,7 +172,8 @@ def read_response(sock):
   data_begin_pos, write_pos = read_headers(sock, buf)
   status, headers = parse_headers(buf, data_begin_pos)
   clen = int(headers["Content-Length"])
-  remaining = write_pos - data_begin_pos - clen
+  buffered = write_pos - data_begin_pos
+  remaining = clen - buffered
   if remaining > 0:
     view = memoryview(buf)
     for _ in range(32):


### PR DESCRIPTION
This PR  fixes the test-only problem #45 , see details in that issue. It was happening rarely because the responses are short and were almost always buffered fully (including the body) on the first read.