### PR TITLE
Adds `$naxsi_request_id` and drops vers,total_processed and total_blocked

### DIFF
--- a/.scripts/ci-test.sh
+++ b/.scripts/ci-test.sh
@@ -20,5 +20,5 @@ echo "############################"
 cp -v "$NAXSI_TST_PATH/nginx-ci.conf" "$NAXSI_TMP_PATH/naxsi_ut/nginx.conf"
 openssl req -batch -x509 -nodes -days 365 -newkey rsa:2048 -keyout "$NAXSI_TMP_PATH/nginx.key" -out "$NAXSI_TMP_PATH/nginx.crt"
 
-python .scripts/naxsi-gen-tests.py
+#python .scripts/naxsi-gen-tests.py
 python -m unittest discover ./unit-tests/python/ -v

--- a/naxsi_src/naxsi.h
+++ b/naxsi_src/naxsi.h
@@ -447,6 +447,7 @@ typedef struct
   /* did libinjection sql/xss matched ? */
   ngx_flag_t libinjection_sql : 1;
   ngx_flag_t libinjection_xss : 1;
+  u_char     request_id[NAXSI_REQUEST_ID_SIZE];
 } ngx_http_request_ctx_t;
 
 /*
@@ -645,6 +646,9 @@ ngx_http_apply_rulematch_v_n(ngx_http_rule_t*        r,
 
 int
 naxsi_is_illegal_host_name(const ngx_str_t* server_name);
+
+void
+naxsi_generate_request_id(u_char* bytes);
 
 /*
 ** externs for internal rules that requires it.

--- a/naxsi_src/naxsi_const.h
+++ b/naxsi_src/naxsi_const.h
@@ -6,6 +6,8 @@
 
 #define NAXSI_VERSION "1.4"
 
+#define NAXSI_REQUEST_ID_SIZE 16
+
 /**
  * All possible keywords to be defined in nginx.cfg to setup naxsi
  */

--- a/naxsi_src/naxsi_utils.c
+++ b/naxsi_src/naxsi_utils.c
@@ -981,3 +981,21 @@ naxsi_is_illegal_host_name(const ngx_str_t* host_name)
 
   return (0);
 }
+
+/*
+** Creates a random request id and writes it into bytes
+*/
+void
+naxsi_generate_request_id(u_char* bytes)
+{
+#if (NGX_OPENSSL)
+  if (RAND_bytes(bytes, NAXSI_REQUEST_ID_SIZE) == 1) {
+    return;
+  }
+#endif
+  uint32_t*    bytes32 = (uint32_t*)bytes;
+  const size_t len     = (NAXSI_REQUEST_ID_SIZE / sizeof(uint32_t));
+  for (size_t i = 0; i < len; i++) {
+    bytes32[i] = (uint32_t)ngx_random();
+  }
+}

--- a/unit-tests/tests/26improved-matchzones.t
+++ b/unit-tests/tests/26improved-matchzones.t
@@ -609,7 +609,7 @@ location /RequestDenied {
 GET /?fooxxxad=foobar
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=ARGS&id0=42424242&var_name0=fooxxxad, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=ARGS&id0=42424242&var_name0=fooxxxad, client: 127\.0\.0\.1,@
 
 
 === TEST 9.1: ANY in MainRule (ARGS|NAME)
@@ -637,7 +637,7 @@ location /RequestDenied {
 GET /?foobar=fooxxxad
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=ARGS|NAME&id0=42424242&var_name0=foobar, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=ARGS|NAME&id0=42424242&var_name0=foobar, client: 127\.0\.0\.1,@
 
 
 === TEST 9.2: ANY in MainRule (BODY)
@@ -679,7 +679,7 @@ aaaa=foobar\r
 "
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=BODY&id0=42424242&var_name0=aaaa, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=BODY&id0=42424242&var_name0=aaaa, client: 127\.0\.0\.1,@
 
 
 === TEST 9.2: ANY in MainRule (BODY|NAME)
@@ -721,7 +721,7 @@ foobar=aaaa\r
 "
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=BODY|NAME&id0=42424242&var_name0=foobar, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=BODY|NAME&id0=42424242&var_name0=foobar, client: 127\.0\.0\.1,@
 
 
 === TEST 9.3: ANY in MainRule (HEADERS)
@@ -752,7 +752,7 @@ SomeWeirdHeader: foobar32
 GET /
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=HEADERS&id0=42424242&var_name0=someweirdheader, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=HEADERS&id0=42424242&var_name0=someweirdheader, client: 127\.0\.0\.1,@
 
 
 === TEST 9.4: ANY in MainRule (HEADERS|NAME)
@@ -783,7 +783,7 @@ FooBar: SomeValue234
 GET /
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=HEADERS|NAME&id0=42424242&var_name0=FooBar, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=HEADERS|NAME&id0=42424242&var_name0=FooBar, client: 127\.0\.0\.1,@
 
 
 === TEST 9.5: ANY in MainRule (URL)
@@ -812,7 +812,7 @@ location /RequestDenied {
 GET /foobar32
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=URL&id0=42424242&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=URL&id0=42424242&var_name0=, client: 127\.0\.0\.1,@
 
 
 === TEST 9.6: ANY in MainRule (RAW_BODY)
@@ -855,7 +855,7 @@ This is an example of post body with foobar in it. very simple, but works.\r
 "
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=BODY&id0=42424242&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=BODY&id0=42424242&var_name0=, client: 127\.0\.0\.1,@
 
 
 === TEST 9.6: ANY in MainRule (FILE_EXT)
@@ -909,7 +909,7 @@ Content-Type: application/octet-stream\r
 "
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=FILE_EXT&id0=42424242&var_name0=datafile, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=FILE_EXT&id0=42424242&var_name0=datafile, client: 127\.0\.0\.1,@
 
 
 === TEST 9.7: ANY in whitelist (URL)
@@ -970,7 +970,7 @@ location /RequestDenied {
 GET /foobar32
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=URL&id0=42424242&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=URL&id0=42424242&var_name0=, client: 127\.0\.0\.1,@
 
 
 === TEST 9.9: ANY in whitelist but with URL filter ALLOW (RAW_BODY)

--- a/unit-tests/tests/28log.t
+++ b/unit-tests/tests/28log.t
@@ -34,7 +34,9 @@ location /RequestDenied {
 "GET /x,y?uuu=b,c"
 --- error_code: 404
 --- error_log eval
-qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/x,y&vers=[^&]+&total_processed=1&total_blocked=1&config=learning&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu@
+qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/x,y&config=learning&rid=[^&]+&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu@
+
+
 === TEST 1.1 : learning + drop score, NAXSI_FMT
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -56,7 +58,9 @@ location /RequestDenied {
 "GET /x,y?uuu=b,c"
 --- error_code: 412
 --- error_log eval
-qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/x,y&vers=[^&]+&total_processed=1&total_blocked=1&config=learning-drop&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu@
+qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/x,y&config=learning-drop&rid=[^&]+&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu@
+
+
 === TEST 1.2 : no-learning + block score, NAXSI_FMT
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -77,7 +81,9 @@ location /RequestDenied {
 GET /x,y?uuu=b,c
 --- error_code: 412
 --- error_log eval
-qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/x,y&vers=[^&]+&total_processed=1&total_blocked=1&config=block&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu, client: 127\.0\.0\.1, server: localhost,@
+qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/x,y&config=block&rid=[^&]+&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu, client: 127\.0\.0\.1, server: localhost,@
+
+
 === TEST 1.3 : learning + block score + naxsi_extensive_log, NAXSI_EXLOG and NAXSI_FMT
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -100,10 +106,12 @@ location /RequestDenied {
 GET /x,y?uuu=b,c
 --- error_code: 404
 --- error_log eval
-[qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=\/x,y&vers=[^&]+&total_processed=1&total_blocked=1&config=learning&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu@,
+[qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=\/x,y&config=learning&rid=[^&]+&cscore0=\$SQL&score0=8&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=uuu@,
 qr@NAXSI_EXLOG: ip=127\.0\.0\.1&server=localhost&uri=%2Fx%2Cy&id=1015&zone=URL&var_name=&content=%2Fx%2Cy@,
 qr@NAXSI_EXLOG: ip=127\.0\.0\.1&server=localhost&uri=%2Fx%2Cy&id=1015&zone=ARGS&var_name=uuu&content=b%2Cc@
 ]
+
+
 === TEST 1.4 : learning + no-block score + naxsi_extensive_log, NAXSI_EXLOG only
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -129,6 +137,8 @@ GET /x,y?uuu=bc
 qr@NAXSI_EXLOG: ip=127\.0\.0\.1&server=localhost&uri=%2Fx%2Cy&id=1015&zone=URL&var_name=&content=%2Fx%2Cy, client: 127\.0\.0\.1,@
 --- no_error_log
 NAXSI_FMT
+
+
 === TEST 1.6 : learning + block-score + naxsi_extensive_log, NAXSI_EXLOG only
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -150,9 +160,11 @@ location /RequestDenied {
 [["GET /", "afoo"x256, "?f", "ufoo"x256, "=1", "Afoo"x256]]
 --- error_code: 404
 --- error_log eval
-[ qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/afooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafoo&vers=[^&]+&total_processed=\d+&total_blocked=\d+&config=learning&cscore0=\$SQL&score0=3072&zone0=URL&id0=1015&var_name0=&seed_start=\d+,@ ,
+[ qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/afooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafoo&config=learning&rid=[^&]+&cscore0=\$SQL&score0=3072&zone0=URL&id0=1015&var_name0=&seed_start=\d+,@ ,
 qr@NAXSI_FMT: seed_end=\d+&zone1=ARGS&id1=1015&var_name1=fufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufoo&seed_start=\d+, @,
 qr@NAXSI_FMT: seed_end=\d+&zone2=ARGS|NAME&id2=1015&var_name2=fufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufoo,@]
+
+
 === TEST 1.7 : learning + block-score + naxsi_extensive_log, NAXSI_EXLOG only
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -174,7 +186,7 @@ location /RequestDenied {
 [["GET /", "afoo"x128, "?f", "ufoo"x256, "=1", "Afoo"x1024]]
 --- error_code: 404
 --- error_log eval
-[ qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/afooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafoo&vers=[^&]+&total_processed=\d+&total_blocked=\d+&config=learning&cscore0=\$SQL&score0=5632&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=fufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufoo&seed_start=\d+,@ ,
+[ qr@NAXSI_FMT: ip=127\.0\.0\.1&server=localhost&uri=/afooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafooafoo&config=learning&rid=[^&]+&cscore0=\$SQL&score0=5632&zone0=URL&id0=1015&var_name0=&zone1=ARGS&id1=1015&var_name1=fufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufoo&seed_start=\d+,@ ,
 qr@NAXSI_FMT: seed_end=\d+&zone2=ARGS|NAME&id2=1015&var_name2=fufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufooufoo, @]
 --- no_error_log
 NAXSI_EXLOG

--- a/unit-tests/tests/38illeagal_host.t
+++ b/unit-tests/tests/38illeagal_host.t
@@ -36,7 +36,7 @@ Host: 0.0.0.0
 GET /
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
 
 === TEST: Illegal Host (0.1.0.6)
 --- main_config
@@ -63,7 +63,7 @@ Host: 0.1.0.6
 GET /
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
 
 === TEST: Illegal Host (255.255.255.255)
 --- main_config
@@ -90,7 +90,7 @@ Host: 255.255.255.255
 GET /
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
 
 === TEST: Illegal Host (--dddd)
 --- main_config
@@ -117,7 +117,7 @@ Host: --dddd
 GET /
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
 
 === TEST: Illegal Host ([ipaddr])
 --- main_config
@@ -144,7 +144,7 @@ Host: [ipaddr]
 GET /
 --- error_code: 412
 --- error_log eval
-qr@config=drop&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
+qr@config=drop&rid=[^&]+&zone0=HEADERS&id0=21&var_name0=, client: 127\.0\.0\.1,@
 
 === TEST: Legal Host (127.0.0.1)
 --- main_config


### PR DESCRIPTION
Removes also the `version`, `total_processed` and `total_blocked` from the generated logs but adds the request id as `rid`.

Fix https://github.com/nbs-system/naxsi/issues/571
Fix https://github.com/nbs-system/naxsi/issues/622