### PR TITLE
Drop libinjection submodule and build with external libinjection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "naxsi_src/libinjection"]
-	path = naxsi_src/libinjection
-	url = https://github.com/libinjection/libinjection

--- a/naxsi_src/config
+++ b/naxsi_src/config
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: 2019 Giovanni Dante Grazioli <gda@nbs-system.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# libinjection detection
+LIBINJECTION_LIBS="$(pkg-config --libs libinjection)"
+LIBINJECTION_CFLAGS="$(pkg-config --cflags libinjection)"
+
+CFLAGS="$CFLAGS $LIBINJECTION_CFLAGS"
+ngx_feature_libs="$LIBINJECTION_LIBS"
+
 # NAXSI include files
 naxsi_includes="
     $ngx_addon_dir/naxsi.h \
@@ -8,14 +15,6 @@ naxsi_includes="
     $ngx_addon_dir/naxsi_config.h \
     $ngx_addon_dir/naxsi_net.h \
 "
-
-# prepend ngx_config.h to libinjection sources, copy headers
-mkdir -p $ngx_addon_dir/libinjection_ngxbuild
-cp $ngx_addon_dir/libinjection/src/*.h $ngx_addon_dir/libinjection_ngxbuild/
-for src_file in libinjection_html5.c libinjection_sqli.c libinjection_xss.c ; do
-    echo "#include <ngx_config.h>" > $ngx_addon_dir/libinjection_ngxbuild/$src_file
-    cat $ngx_addon_dir/libinjection/src/$src_file >> $ngx_addon_dir/libinjection_ngxbuild/$src_file
-done;
 
 # NAXSI C source files
 naxsi_sources="
@@ -28,9 +27,6 @@ naxsi_sources="
     $ngx_addon_dir/naxsi_utf8.c \
     $ngx_addon_dir/naxsi_utils.c \
     $ngx_addon_dir/naxsi_windows.c \
-    $ngx_addon_dir/libinjection_ngxbuild/libinjection_html5.c \
-    $ngx_addon_dir/libinjection_ngxbuild/libinjection_sqli.c \
-    $ngx_addon_dir/libinjection_ngxbuild/libinjection_xss.c \
 "
 
 CFLAGS="$CFLAGS -DLIBINJECTION_VERSION=0"

--- a/naxsi_src/naxsi.h
+++ b/naxsi_src/naxsi.h
@@ -16,8 +16,8 @@
 #include <naxsi_const.h>
 #include <naxsi_net.h>
 
-#include "libinjection/src/libinjection_sqli.h"
-#include "libinjection/src/libinjection_xss.h"
+#include <libinjection_sqli.h>
+#include <libinjection_xss.h>
 
 #ifdef _WIN32
 #include <naxsi_windows.h>


### PR DESCRIPTION
This is an adaptation of the patch I made for shipping the naxsi module in Fedora.