### PR TITLE
Fix IgnoreIP/IgnoreCIDR inheritance

### DIFF
--- a/.scripts/ci-test.sh
+++ b/.scripts/ci-test.sh
@@ -4,10 +4,10 @@
 
 RUN_TEST="$1"
 
-if command -v python &> /dev/null ; then
-    PYTHON=python
-elif command -v python3 &> /dev/null ; then
+if command -v python3 &> /dev/null ; then
     PYTHON=python3
+elif command -v python &> /dev/null ; then
+    PYTHON=python
 else
     echo "Cannot find python.."
     exit 1

--- a/.scripts/naxsi-gen-tests.py
+++ b/.scripts/naxsi-gen-tests.py
@@ -88,17 +88,15 @@ def parse_test(lines, test_file, line_num):
     curl = True
     idx = idx + 1
   if lines[idx].lstrip().startswith("--- curl_protocol:"):
-    prefix_len = len("--- curl_protocol: ")
-    curl_protocol = lines[idx].strip()[prefix_len:]
+    curl_protocol = lines[idx].strip()[len("--- curl_protocol:"):]
     idx = idx + 1
   if lines[idx].lstrip().startswith("--- curl_options:"):
-    prefix_len = len("--- curl_options: ")
-    curl_options = lines[idx].strip()[prefix_len:]
+    curl_options = lines[idx].strip()[len("--- curl_options:"):]
     idx = idx + 1
   if not lines[idx].lstrip().startswith("--- error_code: "):
     print("ERROR: Cannot parse test defintion, file: [{}], line: [{}]".format(test_file,  line_num + idx - 2))
     sys.exit(1)
-  prefix_len = len("--- error_code: ")
+  prefix_len = len("--- error_code:")
   error_code = int(lines[idx].lstrip()[prefix_len:])
   if idx < len(lines) - 2 and lines[idx + 1].lstrip().startswith("--- error_log"):
     idx += 2

--- a/.scripts/naxsi-gen-tests.py
+++ b/.scripts/naxsi-gen-tests.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from os import path, replace
 import re
 
-NginxTest = namedtuple("NginxTest", "filename name user_files main_config http_config config more_headers request raw_request error_code, error_log no_error_log response_body")
+NginxTest = namedtuple("NginxTest", "filename name user_files main_config http_config config more_headers request raw_request curl curl_protocol curl_options error_code, error_log no_error_log response_body")
 
 unique_fun_names = set()
 
@@ -58,6 +58,9 @@ def parse_test(lines, test_file, line_num):
   more_headers = []
   request = []
   raw_request = []
+  curl = False
+  curl_protocol = "http"
+  curl_options = ""
   error_code = 0
   error_log = []
   no_error_log = []
@@ -81,6 +84,17 @@ def parse_test(lines, test_file, line_num):
     idx = collect_section(lines, idx, request)
   if lines[idx].lstrip().startswith("--- raw_request"):
     idx = collect_section(lines, idx, raw_request)
+  if lines[idx].lstrip().startswith("--- curl"):
+    curl = True
+    idx = idx + 1
+  if lines[idx].lstrip().startswith("--- curl_protocol:"):
+    prefix_len = len("--- curl_protocol: ")
+    curl_protocol = lines[idx].strip()[prefix_len:]
+    idx = idx + 1
+  if lines[idx].lstrip().startswith("--- curl_options:"):
+    prefix_len = len("--- curl_options: ")
+    curl_options = lines[idx].strip()[prefix_len:]
+    idx = idx + 1
   if not lines[idx].lstrip().startswith("--- error_code: "):
     print("ERROR: Cannot parse test defintion, file: [{}], line: [{}]".format(test_file,  line_num + idx - 2))
     sys.exit(1)
@@ -101,7 +115,7 @@ def parse_test(lines, test_file, line_num):
   if idx < len(lines) - 1 and lines[idx + 1].lstrip().startswith("--- response_body"):
     idx+=1
     response_body.append(lines[idx][18:].strip())
-  return NginxTest(filename, name, user_files, main_config, http_config, config, more_headers, request, raw_request, error_code, error_log, no_error_log, response_body)
+  return NginxTest(filename, name, user_files, main_config, http_config, config, more_headers, request, raw_request, curl, curl_protocol, curl_options, error_code, error_log, no_error_log, response_body)
 
 def read_list_of_tests(test_file):
   tests = []
@@ -328,6 +342,15 @@ def gen_request(test):
   if data is not None:
     res += '''
         data="""{}""",'''.format(data)
+  if test.curl:
+    res += '''
+        curl=True,'''
+    if len(test.curl_protocol) > 0:
+      res += '''
+        curl_protocol="{}",'''.format(test.curl_protocol)
+    if len(test.curl_options) > 0:
+      res += '''
+        curl_options="{}",'''.format(test.curl_options)
   if len(test.response_body) > 0:
     res += '''
         resp_body_required=True'''

--- a/unit-tests/python/_test_utils.py
+++ b/unit-tests/python/_test_utils.py
@@ -262,13 +262,8 @@ def send_curl(port, url_path, method, headers, data, curl_protocol, curl_options
   if errs is not None and len(errs) > 0:
     print('WARNING: curl command generates stderr output: "{}"'.format(errs))
 
-  if is_posix():
-    crlf = "\n"
-  else:
-    crlf = "\r\n"
+  crlf = "\n"
   data_begin_pos = 0
-  print(bytearray(crlf, "utf-8"))
-  print(bytearray(outs, "utf-8"))
   for i in range(len(crlf)*2, len(outs)):
     if crlf+crlf == outs[i - len(crlf)*2:i]:
       data_begin_pos = i

--- a/unit-tests/python/_test_utils.py
+++ b/unit-tests/python/_test_utils.py
@@ -267,6 +267,8 @@ def send_curl(port, url_path, method, headers, data, curl_protocol, curl_options
   else:
     crlf = "\r\n"
   data_begin_pos = 0
+  print(bytearray(crlf, "utf-8"))
+  print(bytearray(outs, "utf-8"))
   for i in range(len(crlf)*2, len(outs)):
     if crlf+crlf == outs[i - len(crlf)*2:i]:
       data_begin_pos = i

--- a/unit-tests/python/_test_utils.py
+++ b/unit-tests/python/_test_utils.py
@@ -230,7 +230,7 @@ def send_curl(port, url_path, method, headers, data, curl_protocol, curl_options
     curl_exe = ["curl.exe"]
   curl_exe.extend(['-i', '-H', 'User-Agent:', '-H', 'Accept:', '-sS'])
   if curl_options is not None and len(curl_options) > 0:
-    curl_exe.append("'{}'".format(curl_options))
+    curl_exe.extend(curl_options.split())
   if not includes_header(headers, "Host"):
     curl_exe.extend(['-H', "'Host: localhost'"])
   for name, val in headers.items():
@@ -259,8 +259,8 @@ def send_curl(port, url_path, method, headers, data, curl_protocol, curl_options
     if errs is not None and len(errs) > 0:
       raise NaxsiTestException('ERROR: curl command generates stderr output: "{}"'.format(errs))
     raise NaxsiTestException('ERROR: curl command generates no stdout output')
-#  if errs is not None and len(errs) > 0:
-#    print('WARNING: curl command generates stderr output: "{}"'.format(errs))
+  if errs is not None and len(errs) > 0:
+    print('WARNING: curl command generates stderr output: "{}"'.format(errs))
 
   if is_posix():
     crlf = "\n"

--- a/unit-tests/python/_test_utils.py
+++ b/unit-tests/python/_test_utils.py
@@ -223,6 +223,62 @@ def send_raw_request(port, data):
       time.sleep(0.1)
   raise NaxsiTestException("Connection failed, port: [{}]".format(port))
 
+def send_curl(port, url_path, method, headers, data, curl_protocol, curl_options):
+  if is_posix():
+    curl_exe = ["curl"]
+  else:
+    curl_exe = ["curl.exe"]
+  curl_exe.extend(['-i', '-H', 'User-Agent:', '-H', 'Accept:', '-sS'])
+  if curl_options is not None and len(curl_options) > 0:
+    curl_exe.append("'{}'".format(curl_options))
+  if not includes_header(headers, "Host"):
+    curl_exe.extend(['-H', "'Host: localhost'"])
+  for name, val in headers.items():
+    curl_exe.extend(['-H', "'{}: {}'".format(name, val)])
+  if data is not None and len(data) > 0 and not includes_header(headers, "Content-Length"):
+    curl_exe.extend(['-H', "'Content-Length: {}'".format(len(data))])
+  if data is not None and len(data) > 0:
+    curl_exe.extend(['-d', "'{}'".format(data)])
+  if method is not None and len(method) > 0:
+    if "HEAD" == method:
+      curl_exe.append('-I')
+    elif "GET" != method:
+      curl_exe.extend(['-X', "'{}'".format(method)])
+  curl_exe.append('{}://127.0.0.1:{}{}'.format(curl_protocol, port, url_path))
+#  print(curl_exe)
+#  print(" ".join(curl_exe))
+  curl_proc = subprocess.Popen(curl_exe, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
+  curl_proc.wait()
+  try:
+    outs, errs = curl_proc.communicate(timeout=15)
+  except TimeoutExpired:
+    curl_proc.kill()
+    outs, errs = curl_proc.communicate()
+
+  if outs is None or len(outs) == 0:
+    if errs is not None and len(errs) > 0:
+      raise NaxsiTestException('ERROR: curl command generates stderr output: "{}"'.format(errs))
+    raise NaxsiTestException('ERROR: curl command generates no stdout output')
+#  if errs is not None and len(errs) > 0:
+#    print('WARNING: curl command generates stderr output: "{}"'.format(errs))
+
+  if is_posix():
+    crlf = "\n"
+  else:
+    crlf = "\r\n"
+  data_begin_pos = 0
+  for i in range(len(crlf)*2, len(outs)):
+    if crlf+crlf == outs[i - len(crlf)*2:i]:
+      data_begin_pos = i
+      break
+  lines = outs[:data_begin_pos].split(crlf)
+  status = int(lines[0].split(" ")[1])
+  out_headers = {}
+  for ln in lines[1:-2]:
+    parts = ln.split(": ")
+    out_headers[parts[0]] = parts[1]
+  return status, out_headers, outs[data_begin_pos:]
+
 def write_user_files(files):
   nginx_dir = get_nginx_dir()
   for name, value in files.items():
@@ -285,10 +341,13 @@ class nginx_runner():
       kill_nginx(self.proc)
     delete_user_files(self.user_files)
 
-  def request(self, url, method="GET", headers={}, data=None, resp_body_required=False):
+  def request(self, url, method="GET", headers={}, data=None, resp_body_required=False, curl=False, curl_protocol="http", curl_options=""):
     if data is not None and type(data) == str:
       data = data.encode("utf-8")
-    status, _, body = send_request(self.port, url, method, headers, data)
+    if not curl:
+      status, _, body = send_request(self.port, url, method, headers, data)
+    else:
+      status, _, body = send_curl(self.port, url, method, headers, data, curl_protocol, curl_options)
     if resp_body_required:
       return status, body
     else:

--- a/unit-tests/tests/33ignoreip.t
+++ b/unit-tests/tests/33ignoreip.t
@@ -248,5 +248,5 @@ location /RequestDenied {
 --- request
 GET /foobar?a=update/table
 --- curl
---- curl_options: --interface lo
+--- curl_options: --interface 127.0.0.1
 --- error_code: 200

--- a/unit-tests/tests/34ignorecidr.t
+++ b/unit-tests/tests/34ignorecidr.t
@@ -214,3 +214,36 @@ X-Forwarded-For: 2001:4860:4860::8888
 --- request
 GET /?a=<>
 --- error_code: 200
+
+=== TEST 1.8: IgnoreCIDR request inheritance
+--- user_files
+>>> foobar
+foobar text
+--- main_config
+load_module $TEST_NGINX_NAXSI_MODULE_SO;
+--- http_config
+include $TEST_NGINX_NAXSI_RULES;
+--- config
+location / {
+     SecRulesEnabled;
+     IgnoreCIDR  "127.0.0.0/24";
+     DeniedUrl "/RequestDenied";
+     CheckRule "$SQL >= 8" BLOCK;
+     CheckRule "$RFI >= 8" BLOCK;
+     CheckRule "$TRAVERSAL >= 4" BLOCK;
+     CheckRule "$XSS >= 8" BLOCK;
+     root $TEST_NGINX_SERVROOT/html/;
+     index index.html index.htm;
+
+     location /foobar {
+          BasicRule wl:10;
+     }
+}
+location /RequestDenied {
+     return 412;
+}
+--- request
+GET /foobar?a=update/table
+--- curl
+--- curl_options: --interface lo
+--- error_code: 200

--- a/unit-tests/tests/34ignorecidr.t
+++ b/unit-tests/tests/34ignorecidr.t
@@ -245,5 +245,5 @@ location /RequestDenied {
 --- request
 GET /foobar?a=update/table
 --- curl
---- curl_options: --interface lo
+--- curl_options: --interface 127.0.0.1
 --- error_code: 200


### PR DESCRIPTION
Hi
In a simple config:
```load_module     modules/ngx_http_naxsi_module.so;
error_log       log/error_debug.log debug;

events {
    worker_connections  128;
}

http {
    include             mime.types;
    default_type        application/octet-stream;

    include             naxsi/naxsi_core.rules;

    server  {
        listen localhost:8888;
        server_name naxsi;

        location /naxsi_test/       {
            SecRulesEnabled;
            DeniedUrl "/NaxsiDeniedAccess";
            IgnoreIP "127.0.0.1";
            CheckRule "$SQL >= 8" BLOCK;

            location /naxsi_test/child/     {
                BasicRule wl:10;
                return 200 "200 $remote_addr $request_uri\n";
            }
            return 200 "200 $remote_addr $request_uri\n";
        }
        location /NaxsiDeniedAccess {
            return 403 "403 $remote_addr $request_uri\n";
        }
    }
}
```
IgnoreIP does not inherit :cry: 
```
lubomudr@lvl-suse:~/nginx/test> curl  --interface lo -H "Server: naxsi" --url 'http://localhost:8888/naxsi_test/update/table.gif'
200 127.0.0.1 /naxsi_test/update/table.gif
lubomudr@lvl-suse:~/nginx/test> curl  --interface lo -H "Server: naxsi" --url 'http://localhost:8888/naxsi_test/child/update/table.gif'
403 127.0.0.1 /naxsi_test/child/update/table.gif
```
This happens in case of presence BasicRule/IgnoreIP/IgnoreCIDR directives in the nested location and uncondition initialization the ignore_ips/ignore_cidr fields in **single** _ngx_http_naxsi_read_conf_. As a consequence, the _ngx_http_naxsi_merge_loc_conf_ function **always** treats them as configured new values and does not copy from the parent configuration.

Alternatively, separate the processing of these directives into different functions and perform initialization as needed.