### PR TITLE
IgnoreIP/IgnoreCIDR and internal rules

### DIFF
--- a/naxsi_src/naxsi.h
+++ b/naxsi_src/naxsi.h
@@ -567,9 +567,7 @@ ngx_http_nx_json_obj(ngx_json_t* js);
 void
 ngx_http_naxsi_update_current_ctx_status(ngx_http_request_ctx_t*    ctx,
                                          ngx_http_naxsi_loc_conf_t* cf,
-                                         ngx_http_request_t*        r,
-                                         ngx_str_t*                 name,
-                                         ngx_str_t*                 value);
+                                         ngx_http_request_t*        r);
 
 int
 ngx_http_process_basic_rule_buffer(ngx_str_t* str, ngx_http_rule_t* rl, ngx_int_t* match);

--- a/naxsi_src/naxsi.h
+++ b/naxsi_src/naxsi.h
@@ -278,8 +278,6 @@ typedef struct
 
   /* List of scores increased on rule match. */
   ngx_array_t* sscores;
-  ngx_flag_t   sc_block : 1; //
-  ngx_flag_t   sc_allow : 1; //
   // end of specific score tag stuff
   ngx_flag_t block : 1;
   ngx_flag_t allow : 1;
@@ -624,12 +622,6 @@ naxsi_is_illegal_host_name(const ngx_str_t* server_name);
 
 void
 naxsi_generate_request_id(u_char* bytes);
-
-/*
-** externs for internal rules that requires it.
-*/
-extern ngx_http_rule_t* nx_int__libinject_sql;
-extern ngx_http_rule_t* nx_int__libinject_xss;
 
 /*libinjection_xss wrapper not exported by libinject_xss.h.*/
 int

--- a/naxsi_src/naxsi_json.c
+++ b/naxsi_src/naxsi_json.c
@@ -6,26 +6,11 @@
 #include <naxsi.h>
 #include <naxsi_macros.h>
 
+extern ngx_http_rule_t nx_int__invalid_json;
+
 #define json_char(x) ((x)->src + (x)->off)
 
 //#define _debug_json 1
-
-ngx_http_rule_t nx_int__invalid_json = {
-  0,    /* type */
-  0,    /* whitelist flag */
-  NULL, /* wl_id ptr */
-  15,   /* rule_id */
-  NULL, /* log_msg */
-  0,    /* score */
-  NULL, /* sscores */
-  1,    /* sc_block */
-  0,    /* sc_allow */
-  1,    /* block */
-  0,    /* allow */
-  0,    /* drop */
-  0,    /* log */
-  NULL  /* br ptrs */
-};
 
 ngx_int_t
 ngx_http_nx_json_forward(ngx_json_t* js)

--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -16,129 +16,31 @@
 ** rules at any time ;)
 */
 
-ngx_http_rule_t nx_int__weird_request = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 1,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 0,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
+#define InternalRule(var_name, rule_id, block, drop)             \
+  ngx_http_rule_t var_name = {                                   \
+    /*type*/ 0,            /*whitelist flag*/ 0,                 \
+    /*wl_id ptr*/ NULL,    /*rule_id*/ rule_id,                  \
+    /*log_msg*/ NULL,      /*score*/ 0,                          \
+    /*sscores*/ NULL,                                            \
+    /*block*/ block,       /*allow*/ 0,                          \
+    /*drop*/ drop,         /*log*/ 0,                            \
+    /*br ptrs*/ NULL                                             \
+  }
 
-ngx_http_rule_t nx_int__big_request = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 2,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 0,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__uncommon_hex_encoding = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 10,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 1,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__uncommon_content_type = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 11,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 1,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__uncommon_url = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 12,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 1,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__uncommon_post_format = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 13,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 1,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__uncommon_post_boundary = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 14,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 1,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__empty_post_body = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 16,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 1,     /*sc_allow*/ 0,
-  /*block*/ 1,        /*allow*/ 0,
-  /*drop*/ 0,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t* nx_int__libinject_sql; /*ID:17*/
-ngx_http_rule_t* nx_int__libinject_xss; /*ID:18*/
-
-ngx_http_rule_t nx_int__no_rules = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 19,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 0,     /*sc_allow*/ 0,
-  /*block*/ 0,        /*allow*/ 0,
-  /*drop*/ 1,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__bad_utf8 = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 20,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 0,     /*sc_allow*/ 0,
-  /*block*/ 0,        /*allow*/ 0,
-  /*drop*/ 1,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
-
-ngx_http_rule_t nx_int__illegal_host_header = {
-  /*type*/ 0,         /*whitelist flag*/ 0,
-  /*wl_id ptr*/ NULL, /*rule_id*/ 21,
-  /*log_msg*/ NULL,   /*score*/ 0,
-  /*sscores*/ NULL,
-  /*sc_block*/ 0,     /*sc_allow*/ 0,
-  /*block*/ 0,        /*allow*/ 0,
-  /*drop*/ 1,         /*log*/ 0,
-  /*br ptrs*/ NULL
-};
+InternalRule(nx_int__weird_request,           1, 1, 0);
+InternalRule(nx_int__big_request,             2, 1, 0);
+InternalRule(nx_int__uncommon_hex_encoding,  10, 1, 0);
+InternalRule(nx_int__uncommon_content_type,  11, 1, 0);
+InternalRule(nx_int__uncommon_url,           12, 1, 0);
+InternalRule(nx_int__uncommon_post_format,   13, 1, 0);
+InternalRule(nx_int__uncommon_post_boundary, 14, 1, 0);
+InternalRule(nx_int__invalid_json,           15, 1, 0);
+InternalRule(nx_int__empty_post_body,        16, 1, 0);
+InternalRule(nx_int__libinject_sql,          17, 1, 0);
+InternalRule(nx_int__libinject_xss,          18, 1, 0);
+InternalRule(nx_int__no_rules,               19, 0, 1);
+InternalRule(nx_int__bad_utf8,               20, 0, 1);
+InternalRule(nx_int__illegal_host_header,    21, 0, 1);
 
 #define naxsi_error_fatal(ctx, r, ...)                                                             \
   do {                                                                                             \
@@ -1953,7 +1855,7 @@ ngx_http_libinjection(ngx_pool_t*             pool,
     libinjection_sqli_init(&state, (const char*)name->data, name->len, FLAG_NONE);
     issqli = libinjection_is_sqli(&state);
     if (issqli == 1) {
-      ngx_http_apply_rulematch_v_n(nx_int__libinject_sql, ctx, req, name, value, zone, 1, 1);
+      ngx_http_apply_rulematch_v_n(&nx_int__libinject_sql, ctx, req, name, value, zone, 1, 1);
     }
 
     /* hardcoded call to libinjection on CONTENT, apply internal rule if
@@ -1961,7 +1863,7 @@ ngx_http_libinjection(ngx_pool_t*             pool,
     libinjection_sqli_init(&state, (const char*)value->data, value->len, FLAG_NONE);
     issqli = libinjection_is_sqli(&state);
     if (issqli == 1) {
-      ngx_http_apply_rulematch_v_n(nx_int__libinject_sql, ctx, req, name, value, zone, 1, 0);
+      ngx_http_apply_rulematch_v_n(&nx_int__libinject_sql, ctx, req, name, value, zone, 1, 0);
     }
   }
 
@@ -1969,14 +1871,14 @@ ngx_http_libinjection(ngx_pool_t*             pool,
     /* first on var_name */
     issqli = libinjection_xss((const char*)name->data, name->len);
     if (issqli == 1) {
-      ngx_http_apply_rulematch_v_n(nx_int__libinject_xss, ctx, req, name, value, zone, 1, 1);
+      ngx_http_apply_rulematch_v_n(&nx_int__libinject_xss, ctx, req, name, value, zone, 1, 1);
     }
 
     /* hardcoded call to libinjection on CONTENT, apply internal rule if
      * matched. */
     issqli = libinjection_xss((const char*)value->data, value->len);
     if (issqli == 1) {
-      ngx_http_apply_rulematch_v_n(nx_int__libinject_xss, ctx, req, name, value, zone, 1, 0);
+      ngx_http_apply_rulematch_v_n(&nx_int__libinject_xss, ctx, req, name, value, zone, 1, 0);
     }
   }
 }
@@ -2972,12 +2874,10 @@ ngx_http_naxsi_data_parse(ngx_http_request_ctx_t* ctx, ngx_http_request_t* r)
 {
   ngx_http_naxsi_loc_conf_t*  cf;
   ngx_http_naxsi_main_conf_t* main_cf;
-  ngx_http_core_main_conf_t*  cmcf;
 
   cf      = ngx_http_get_module_loc_conf(r, ngx_http_naxsi_module);
-  cmcf    = ngx_http_get_module_main_conf(r, ngx_http_core_module);
   main_cf = ngx_http_get_module_main_conf(r, ngx_http_naxsi_module);
-  if (!cf || !ctx || !cmcf) {
+  if (!cf || !ctx) {
     ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "naxsi: unable to parse data.");
     return;
   }

--- a/naxsi_src/naxsi_skeleton.c
+++ b/naxsi_src/naxsi_skeleton.c
@@ -592,6 +592,10 @@ ngx_http_naxsi_merge_loc_conf(ngx_conf_t* cf, void* parent, void* child)
 ** and will call the hashtable creation function
 ** (whitelist aggregation)
 */
+
+extern ngx_http_rule_t nx_int__libinject_sql;
+extern ngx_http_rule_t nx_int__libinject_xss;
+
 static ngx_int_t
 ngx_http_naxsi_init(ngx_conf_t* cf)
 {
@@ -654,21 +658,13 @@ ngx_http_naxsi_init(ngx_conf_t* cf)
   ** initalise internal rules for libinjection sqli/xss
   ** (needs proper special scores)
   */
-  nx_int__libinject_sql = ngx_pcalloc(cf->pool, sizeof(ngx_http_rule_t));
-  nx_int__libinject_xss = ngx_pcalloc(cf->pool, sizeof(ngx_http_rule_t));
-  if (!nx_int__libinject_xss || !nx_int__libinject_sql)
-    return (NGX_ERROR);
-  nx_int__libinject_sql->sscores = ngx_array_create(cf->pool, 2, sizeof(ngx_http_special_score_t));
-  nx_int__libinject_xss->sscores = ngx_array_create(cf->pool, 2, sizeof(ngx_http_special_score_t));
-  if (!nx_int__libinject_sql->sscores || !nx_int__libinject_xss->sscores)
+  nx_int__libinject_sql.sscores = ngx_array_create(cf->pool, 2, sizeof(ngx_http_special_score_t));
+  nx_int__libinject_xss.sscores = ngx_array_create(cf->pool, 2, sizeof(ngx_http_special_score_t));
+  if (!nx_int__libinject_sql.sscores || !nx_int__libinject_xss.sscores)
     return (NGX_ERROR); /* LCOV_EXCL_LINE */
-  /* internal ID sqli - 17*/
-  nx_int__libinject_sql->rule_id = 17;
-  /* internal ID xss - 18*/
-  nx_int__libinject_xss->rule_id = 18;
   /* libinjection sqli/xss - special score init */
-  ngx_http_special_score_t* libjct_sql = ngx_array_push(nx_int__libinject_sql->sscores);
-  ngx_http_special_score_t* libjct_xss = ngx_array_push(nx_int__libinject_xss->sscores);
+  ngx_http_special_score_t* libjct_sql = ngx_array_push(nx_int__libinject_sql.sscores);
+  ngx_http_special_score_t* libjct_xss = ngx_array_push(nx_int__libinject_xss.sscores);
   if (!libjct_sql || !libjct_xss)
     return (NGX_ERROR); /* LCOV_EXCL_LINE */
   libjct_sql->sc_tag = ngx_pcalloc(cf->pool, sizeof(ngx_str_t));

--- a/unit-tests/tests/33ignoreip.t
+++ b/unit-tests/tests/33ignoreip.t
@@ -250,3 +250,26 @@ GET /foobar?a=update/table
 --- curl
 --- curl_options: --interface 127.0.0.1
 --- error_code: 200
+
+=== TEST 1.9: IgnoreIP internal rules
+--- user_files
+>>> foobar
+foobar text
+--- main_config
+load_module $TEST_NGINX_NAXSI_MODULE_SO;
+--- http_config
+include $TEST_NGINX_NAXSI_RULES;
+--- config
+location / {
+     SecRulesEnabled;
+     IgnoreIP  "127.0.0.1";
+     DeniedUrl "/RequestDenied";
+     root $TEST_NGINX_SERVROOT/html/;
+     index index.html index.htm;
+}
+location /RequestDenied {
+     return 412;
+}
+--- request
+PUT /foobar
+--- error_code: 405

--- a/unit-tests/tests/34ignorecidr.t
+++ b/unit-tests/tests/34ignorecidr.t
@@ -247,3 +247,26 @@ GET /foobar?a=update/table
 --- curl
 --- curl_options: --interface 127.0.0.1
 --- error_code: 200
+
+=== TEST 1.9: IgnoreCIDR internal rules
+--- user_files
+>>> foobar
+foobar text
+--- main_config
+load_module $TEST_NGINX_NAXSI_MODULE_SO;
+--- http_config
+include $TEST_NGINX_NAXSI_RULES;
+--- config
+location / {
+     SecRulesEnabled;
+     IgnoreCIDR  "127.0.0.0/24";
+     DeniedUrl "/RequestDenied";
+     root $TEST_NGINX_SERVROOT/html/;
+     index index.html index.htm;
+}
+location /RequestDenied {
+     return 412;
+}
+--- request
+PUT /foobar
+--- error_code: 405


### PR DESCRIPTION
Hi
IgnoreIP/IgnoreCIDR does not work for rules without SpecialScores (all internal rules except injections) :worried: 

Additionally, some cosmetic improvements to define internal rules
