### PR TITLE
Remove X-Forwarded-For header special processing

### DIFF
--- a/.scripts/ci-build.sh
+++ b/.scripts/ci-build.sh
@@ -49,6 +49,7 @@ if $NEW_BUILD ; then
                 --without-mail_pop3_module \
                 --without-mail_smtp_module \
                 --without-mail_imap_module \
+                --with-http_realip_module \
                 --with-http_v2_module \
                 --without-http_uwsgi_module \
                 --without-http_scgi_module \

--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -2912,36 +2912,6 @@ ngx_http_naxsi_update_current_ctx_status(ngx_http_request_ctx_t*    ctx,
   NX_DEBUG(_debug_custom_score, NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "XX-custom check rules");
 
   if (!ctx->ignore && (cf->ignore_ips || cf->ignore_cidrs)) {
-#if (NGX_HTTP_X_FORWARDED_FOR)
-#if (nginx_version < 1023000)
-    ngx_table_elt_t** h;
-    if (r->headers_in.x_forwarded_for.nelts >= 1) {
-      h = r->headers_in.x_forwarded_for.elts;
-      NX_DEBUG(_debug_whitelist_ignore,
-               NGX_LOG_DEBUG_HTTP,
-               r->connection->log,
-               0,
-               "XX- lookup ignore X-Forwarded-For: %V",
-               h[0]->value);
-      ngx_str_t* ip = &h[0]->value;
-      ctx->ignore   = naxsi_can_ignore_ip(ip, cf) || naxsi_can_ignore_cidr(ip, cf);
-    } else
-#else
-    ngx_table_elt_t* xff;
-    if (r->headers_in.x_forwarded_for != NULL) {
-      xff = r->headers_in.x_forwarded_for;
-      NX_DEBUG(_debug_whitelist_ignore,
-               NGX_LOG_DEBUG_HTTP,
-               r->connection->log,
-               0,
-               "XX- lookup ignore X-Forwarded-For: %V",
-               xff->value);
-      ngx_str_t* ip = &xff->value;
-      ctx->ignore   = naxsi_can_ignore_ip(ip, cf) || naxsi_can_ignore_cidr(ip, cf);
-    } else
-#endif
-#endif
-    {
       ngx_str_t* ip = &r->connection->addr_text;
       NX_DEBUG(_debug_whitelist_ignore,
                NGX_LOG_DEBUG_HTTP,
@@ -2950,7 +2920,6 @@ ngx_http_naxsi_update_current_ctx_status(ngx_http_request_ctx_t*    ctx,
                "XX- lookup ignore client ip: %V",
                ip);
       ctx->ignore = naxsi_can_ignore_ip(ip, cf) || naxsi_can_ignore_cidr(ip, cf);
-    }
   }
 
   if (cf->check_rules && ctx->special_scores) {

--- a/unit-tests/tests/33ignoreip.t
+++ b/unit-tests/tests/33ignoreip.t
@@ -60,7 +60,7 @@ location /RequestDenied {
 GET /?a=buibui
 --- error_code: 200
 
-=== TEST 1.2: IgnoreIP request with X-Forwarded-For allow (ipv4) 
+=== TEST 1.2.1: IgnoreIP request with X-Forwarded-For allow without real_ip config (ipv4) 
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
 --- http_config
@@ -83,10 +83,38 @@ location /RequestDenied {
 --- more_headers
 X-Forwarded-For: 1.1.1.1
 --- request
-GET /?a=buibui
+GET /?a=<>
+--- error_code: 412
+
+=== TEST 1.2.2: IgnoreIP request with X-Forwarded-For allow with real_ip config (ipv4) 
+--- main_config
+load_module $TEST_NGINX_NAXSI_MODULE_SO;
+--- http_config
+include $TEST_NGINX_NAXSI_RULES;
+set_real_ip_from 127.0.0.1;
+real_ip_header X-Forwarded-For;
+--- config
+location / {
+     SecRulesEnabled;
+     IgnoreIP  "1.1.1.1";
+     DeniedUrl "/RequestDenied";
+     CheckRule "$SQL >= 8" BLOCK;
+     CheckRule "$RFI >= 8" BLOCK;
+     CheckRule "$TRAVERSAL >= 4" BLOCK;
+     CheckRule "$XSS >= 8" BLOCK;
+     root $TEST_NGINX_SERVROOT/html/;
+     index index.html index.htm;
+}
+location /RequestDenied {
+     return 412;
+}
+--- more_headers
+X-Forwarded-For: 1.1.1.1
+--- request
+GET /?a=<>
 --- error_code: 200
 
-=== TEST 1.3: IgnoreIP request with X-Forwarded-For allow (ipv6)
+=== TEST 1.3.1: IgnoreIP request with X-Forwarded-For allow without reaL_ip config (ipv6)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
 --- http_config
@@ -109,7 +137,35 @@ location /RequestDenied {
 --- more_headers
 X-Forwarded-For: 2001:4860:4860::8844
 --- request
-GET /?a=buibui
+GET /?a=<>
+--- error_code: 412
+
+=== TEST 1.3.2: IgnoreIP request with X-Forwarded-For allow with real_ip config (ipv6)
+--- main_config
+load_module $TEST_NGINX_NAXSI_MODULE_SO;
+--- http_config
+include $TEST_NGINX_NAXSI_RULES;
+set_real_ip_from ::1/128;
+real_ip_header X-Forwarded-For;
+--- config
+location / {
+     SecRulesEnabled;
+     IgnoreIP "2001:4860:4860::8844";
+     DeniedUrl "/RequestDenied";
+     CheckRule "$SQL >= 8" BLOCK;
+     CheckRule "$RFI >= 8" BLOCK;
+     CheckRule "$TRAVERSAL >= 4" BLOCK;
+     CheckRule "$XSS >= 8" BLOCK;
+     root $TEST_NGINX_SERVROOT/html/;
+     index index.html index.htm;
+}
+location /RequestDenied {
+     return 412;
+}
+--- more_headers
+X-Forwarded-For: 2001:4860:4860::8844
+--- request
+GET /?a=<>
 --- error_code: 200
 
 === TEST 1.4: IgnoreIP request with X-Forwarded-For deny (ipv4)

--- a/unit-tests/tests/33ignoreip.t
+++ b/unit-tests/tests/33ignoreip.t
@@ -145,7 +145,7 @@ GET /?a=<>
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
 --- http_config
 include $TEST_NGINX_NAXSI_RULES;
-set_real_ip_from ::1/128;
+set_real_ip_from 127.0.0.1;
 real_ip_header X-Forwarded-For;
 --- config
 location / {

--- a/unit-tests/tests/33ignoreip.t
+++ b/unit-tests/tests/33ignoreip.t
@@ -146,6 +146,7 @@ load_module $TEST_NGINX_NAXSI_MODULE_SO;
 --- http_config
 include $TEST_NGINX_NAXSI_RULES;
 set_real_ip_from 127.0.0.1;
+set_real_ip_from ::1/128;
 real_ip_header X-Forwarded-For;
 --- config
 location / {

--- a/unit-tests/tests/34ignorecidr.t
+++ b/unit-tests/tests/34ignorecidr.t
@@ -223,6 +223,7 @@ load_module $TEST_NGINX_NAXSI_MODULE_SO;
 --- http_config
 include $TEST_NGINX_NAXSI_RULES;
 set_real_ip_from 127.0.0.1;
+set_real_ip_from ::1/128;
 real_ip_header X-Forwarded-For;
 --- config
 location / {
@@ -277,6 +278,7 @@ load_module $TEST_NGINX_NAXSI_MODULE_SO;
 --- http_config
 include $TEST_NGINX_NAXSI_RULES;
 set_real_ip_from 127.0.0.1;
+set_real_ip_from ::1/128;
 real_ip_header X-Forwarded-For;
 --- config
 location / {


### PR DESCRIPTION
Hi

The special handling of X-Forwarded-For in runtime.c is a security hole and VERY DANGEROUS.

If the ngx_http_realip_module module configuration is enabled, the NGINX  $remote_addr variable is replaced with X-Forwarded-For if (and only if) the IP packet came from any trusted host in set_real_ip_from.
If the IP packet arrived from any other hosts or the ngx_http_realip_module module is not enabled, processing of the X-Forwarded-For header is ignored.

Handling of the X-Forwarded-For header must be completely transparent to NAXSI