### PR TITLE
Fix: "application/reports+json" request parsing as JSON

### DIFF
--- a/naxsi_src/naxsi_json.c
+++ b/naxsi_src/naxsi_json.c
@@ -144,11 +144,10 @@ ngx_http_nx_json_val(ngx_json_t* js)
   }
   if ((js->c >= '0' && js->c <= '9') || js->c == '-') {
     val.data = json_char(js);
-    while (((*json_char(js) >= '0' && *json_char(js) <= '9') ||
-            *json_char(js) == '.' || *json_char(js) == '+' ||
-            *json_char(js) == '-' || *json_char(js) == 'e' ||
-            *json_char(js) == 'E') &&
-           js->off < js->len) {
+    while (js->off < js->len &&
+           ((*json_char(js) >= '0' && *json_char(js) <= '9') || *json_char(js) == '.' ||
+            *json_char(js) == '+' || *json_char(js) == '-' || *json_char(js) == 'e' ||
+            *json_char(js) == 'E')) {
       val.len++;
       js->off++;
     }

--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -2732,6 +2732,10 @@ ngx_http_naxsi_body_parse(ngx_http_request_ctx_t*     ctx,
   else if (!ngx_strncasecmp(content_type_str, (u_char*)"application/vnd.api+json", 24)) {
     ngx_http_naxsi_json_parse(ctx, r, full_body, full_body_len);
   }
+  /* 24 = echo -n "application/reports+json" | wc -c */
+  else if (!ngx_strncasecmp(content_type_str, (u_char*)"application/reports+json", 24)) {
+    ngx_http_naxsi_json_parse(ctx, r, full_body, full_body_len);
+  }
   /* 22 = echo -n "application/csp-report" | wc -c */
   else if (!ngx_strncasecmp(content_type_str, (u_char*)"application/csp-report", 22)) {
     ngx_http_naxsi_json_parse(ctx, r, full_body, full_body_len);

--- a/unit-tests/tests/14json.t
+++ b/unit-tests/tests/14json.t
@@ -356,7 +356,7 @@ use URI::Escape;
 
 }"
 --- error_code: 412
-=== JSON7 : Valid JSON with empty array item (Extra ',' in array)
+=== JSON7 : inValid JSON with empty array item (Extra ',' in array)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
 --- http_config
@@ -404,7 +404,7 @@ use URI::Escape;
     }
 
 }"
---- error_code: 200
+--- error_code: 412
 === JSON8 : valid JSON - too deep !
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -1013,3 +1013,34 @@ use URI::Escape;
 }
 "
 --- error_code: 200
+
+=== JSON19 : Invalid JSON application/reports+json
+--- main_config
+load_module $TEST_NGINX_NAXSI_MODULE_SO;
+--- http_config
+include $TEST_NGINX_NAXSI_RULES;
+--- config
+location / {
+    SecRulesEnabled;
+    DeniedUrl "/RequestDenied";
+    CheckRule "$SQL >= 8" BLOCK;
+    CheckRule "$RFI >= 8" BLOCK;
+    CheckRule "$TRAVERSAL >= 4" BLOCK;
+    CheckRule "$XSS >= 8" BLOCK;
+    root $TEST_NGINX_SERVROOT/html/;
+    index index.html index.htm;
+    error_page 405 = $uri;
+}
+location /RequestDenied {
+         return 412;
+}
+--- more_headers
+Content-Type: application/reports+json
+--- request eval
+use URI::Escape;
+"POST /
+[{
+    \"name\": \"value\"
+]
+"
+--- error_code: 412

--- a/unit-tests/tests/15json_wl.t
+++ b/unit-tests/tests/15json_wl.t
@@ -427,7 +427,7 @@ use URI::Escape;
   [\"there\", \"is\", \"no\", \"way\"]
 }
 "
---- error_code: 200
+--- error_code: 412
 === json wl 2.0 : malformed json (missing opening {)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;


### PR DESCRIPTION
Hi
Request with Content-Type: application/reports+json now parsing as JSON

Also, JSON processing is in accordance with RFC 7159 standard
In particular, the JSON format "[1,2,]" is incorrect