### PR TITLE
Fix usage of pipe symbol in matchzone

### DIFF
--- a/.scripts/ci-build.sh
+++ b/.scripts/ci-build.sh
@@ -36,7 +36,7 @@ export NGINX_TMP_PATH=$(realpath nginx-source/)
 
 if $NEW_BUILD ; then
     cd "$NGINX_TMP_PATH"
-    ./configure --with-cc-opt='-g -O2 -Wextra -Wall -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2' \
+    ./configure --with-cc-opt='-g -O2 -Wextra -Wall -Wno-error=unterminated-string-initialization -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2' \
                 --with-ld-opt='-Wl,-z,relro -Wl,-z,now -fPIC' \
                 --with-select_module \
                 --conf-path="$NAXSI_TMP_PATH/naxsi_ut/nginx.conf" \

--- a/naxsi_src/naxsi_config.h
+++ b/naxsi_src/naxsi_config.h
@@ -4,6 +4,16 @@
 #ifndef NAXSI_CONFIG_H
 #define NAXSI_CONFIG_H
 
+/* matchzone expected keywords */
+#define MZ_ANY_K      "ANY"
+#define MZ_RAW_BODY_K "RAW_BODY"
+#define MZ_BODY_K     "BODY"
+#define MZ_HEADERS_K  "HEADERS"
+#define MZ_URL_K      "URL"
+#define MZ_ARGS_K     "ARGS"
+#define MZ_NAME_K     "NAME"
+#define MZ_FILE_EXT_K "FILE_EXT"
+
 /* custom match  zones */
 #define MZ_GET_VAR_T      "$ARGS_VAR:"
 #define MZ_HEADER_VAR_T   "$HEADERS_VAR:"

--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -496,6 +496,11 @@ ngx_http_naxsi_pcre_wrapper(ngx_regex_compile_t* rx, unsigned char* str, unsigne
   int match;
   int captures[30];
 
+  if (!rx) {
+    /* special check to ensure all regexes are compiled */
+    return 0;
+  }
+
 #if (NGX_PCRE2)
   match = ngx_pcre2_exec(rx->regex, str, len, 0, captures, 1);
 #elif defined nginx_version && (nginx_version >= 1002002 && nginx_version != 1003000)

--- a/unit-tests/tests/01naxsi_whitelists.t
+++ b/unit-tests/tests/01naxsi_whitelists.t
@@ -34,6 +34,7 @@ location /RequestDenied {
 --- request
 GET /?a=foobar
 --- error_code: 200
+
 === WL TEST 1.0.1: [ARGS zone WhiteList] Adding a test rule in http_config (ARGS zone) and disable rule.
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -59,6 +60,7 @@ location /RequestDenied {
 --- request
 GET /?foobar=a
 --- error_code: 200
+
 === WL TEST 1.1: Adding a test rule in http_config (ARGS zone) and WL it on arg name only.
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -84,6 +86,7 @@ location /RequestDenied {
 --- request
 GET /?a=foobar
 --- error_code: 200
+
 === WL TEST 1.2: Adding a test rule in http_config (ARGS zone) and WL it on arg name only (case sensitiveness check).
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -109,6 +112,7 @@ location /RequestDenied {
 --- request
 GET /?abcd=foobar
 --- error_code: 200
+
 === WL TEST 1.3: Adding a test rule in http_config (ARGS zone) and WL it on arg name only (case sensitiveness check #2).
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -134,6 +138,7 @@ location /RequestDenied {
 --- request
 GET /?AbCd=foobar
 --- error_code: 200
+
 === WL TEST 1.4: Adding a test rule in http_config (ARGS zone) and WL it on $URL + ZONE.
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -159,6 +164,7 @@ location /RequestDenied {
 --- request
 GET /?a=foobar
 --- error_code: 200
+
 === WL TEST 1.5: Adding a test rule in http_config (ARGS zone) and WL it on $URL + ZONE (wrong URL).
 --- user_files
 >>> index2
@@ -187,6 +193,7 @@ location /RequestDenied {
 --- request
 GET /index2?a=foobar
 --- error_code: 412
+
 === WL TEST 1.6: Adding a test rule in http_config (ARGS zone) and WL it on $URL + $ARG_VAR.
 --- user_files
 >>> index2
@@ -215,6 +222,7 @@ location /RequestDenied {
 --- request
 GET /index2?ABCD=foobar
 --- error_code: 412
+
 === WL TEST 2.0: Adding a rule that will match on headers
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -241,6 +249,7 @@ Cookie: foobar
 --- request
 GET /
 --- error_code: 412
+
 === WL TEST 2.1: Adding a rule that will match on headers, WL it on $HEADERS_VAR
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -271,6 +280,7 @@ cookie: foobar
 --- request
 GET /another-page
 --- error_code: 200
+
 === WL TEST 2.2: Adding a rule that will match on headers specific header name
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -300,6 +310,7 @@ COOKIE: foobar
 --- request
 GET /another-page
 --- error_code: 412
+
 === WL TEST 2.3: Adding a rule that will match on headers, WL it by $URL + zone
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -330,6 +341,7 @@ COOKIE: foobar
 --- request
 GET /another-page
 --- error_code: 200
+
 === WL TEST 2.4 : Adding a rule that will match on headers, WL it by $URL + $HEADERS_VAR
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -360,6 +372,7 @@ cookie: foobar
 --- request
 GET /another-page
 --- error_code: 200
+
 === WL TEST 2.5 : Adding a rule that will match on headers, WL it by $URL + $HEADERS_VAR (WRONG URL)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -390,6 +403,7 @@ COOKIE: foobar
 --- request
 GET /another-pag
 --- error_code: 412
+
 === WL TEST 2.6 : Adding a rule that will match on headers, WL it by $URL + $HEADERS_VAR (WRONG HEADER NAME)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -420,6 +434,7 @@ COOKI: foobar
 --- request
 GET /another-page
 --- error_code: 412
+
 === URL WL TEST 3.0: Adding a test rule on ARGS (testing case sensitivness)
 --- user_files
 >>> foobar
@@ -447,6 +462,7 @@ location /RequestDenied {
 --- request
 GET /foobar?a=BrA
 --- error_code: 412
+
 === URL WL TEST 3.1: Adding a test rule on ARGS (testing case sensitivness #2)
 --- user_files
 >>> foobar
@@ -474,6 +490,7 @@ location /RequestDenied {
 --- request
 GET /foobar?a=bRa
 --- error_code: 412
+
 === URL WL TEST 3.2: Adding a test rule on URI (testing case sensitivness #2)
 --- user_files
 >>> foobar
@@ -501,6 +518,7 @@ location /RequestDenied {
 --- request
 GET /FoObar?a=bRa
 --- error_code: 412
+
 === WL TEST 5.0: Testing the POST content-type rule !
 --- user_files
 >>> foobar
@@ -534,6 +552,7 @@ use URI::Escape;
 "POST /foobar
 foo1=bar1&foo2=bar2"
 --- error_code: 200
+
 === WL TEST 5.1: Testing the POST content-type rule #2
 --- user_files
 >>> foobar
@@ -567,6 +586,7 @@ use URI::Escape;
 "POST /foobar
 foo1=bar1&foo2=bar2"
 --- error_code: 412
+
 === WL TEST 5.1: Testing the POST content-type rule #3
 --- user_files
 >>> foobar
@@ -600,6 +620,7 @@ use URI::Escape;
 "POST /foobar
 foo1=bar1&foo2=bar2"
 --- error_code: 412
+
 === WL TEST 5: Adding a test rule in http_config (ARGS zone) and WL it on url + wrong arg name.
 --- user_files
 >>> foobar
@@ -628,6 +649,7 @@ location /RequestDenied {
 --- request
 GET /foobar?baron=foobar
 --- error_code: 412
+
 === WL TEST 6: Adding a test rule in http_config (ARGS zone) and WL it.
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -653,6 +675,7 @@ location /RequestDenied {
 --- request
 GET /?a=foobar
 --- error_code: 200
+
 === WL TEST 7: Adding a test rule in http_config (URL zone) and WL it on url + zone.
 --- user_files
 >>> foobar
@@ -681,6 +704,7 @@ location /RequestDenied {
 --- request
 GET /foobar?aa
 --- error_code: 200
+
 === WL TEST 8: Adding a test rule in http_config (URL zone).
 --- user_files
 >>> foobar
@@ -708,6 +732,7 @@ location /RequestDenied {
 --- request
 GET /foobar?aa
 --- error_code: 412
+
 === WL TEST 8.1 : Adding a test rule in http_config (URL zone) and whitelist it with $URL:|URL.
 --- user_files
 >>> foobar
@@ -736,6 +761,7 @@ location /RequestDenied {
 --- request
 GET /foobar?aa
 --- error_code: 200
+
 === WL TEST 8.2 : Adding a test rule in http_config (URL zone) and whitelist it with URL and no $URL.
 --- user_files
 >>> foobar
@@ -764,6 +790,7 @@ location /RequestDenied {
 --- request
 GET /foobar?aa
 --- error_code: 200
+
 === WL TEST 8: Adding a test rule in http_config (ARGS zone) and WL it on url + arg name.
 --- user_files
 >>> foobar
@@ -792,6 +819,7 @@ location /RequestDenied {
 --- request
 GET /foobar?barone=foobar
 --- error_code: 200
+
 === WL TEST 9: Adding a test rule in http_config (ARGS zone) and WL it on $ARGS_VAR only.
 --- user_files
 >>> foobar
@@ -820,6 +848,7 @@ location /RequestDenied {
 --- request
 GET /foobar?barone=foobar
 --- error_code: 200
+
 === WL TEST 10: Adding a test rule in http_config (ARGS zone) and WL it on url + wrong arg name.
 --- user_files
 >>> foobar
@@ -848,6 +877,7 @@ location /RequestDenied {
 --- request
 GET /foobar?baron=foobar
 --- error_code: 412
+
 === WL TEST 11: Adding a test rule in http_config (ARGS zone) and WL it on url + wrong URL.
 --- user_files
 >>> foobar
@@ -876,6 +906,7 @@ location /RequestDenied {
 --- request
 GET /foobarx?baron=foobar
 --- error_code: 412
+
 === WL TEST 12: Adding a test rule in http_config (ARGS zone) and WL it on url + wrong arg name.
 --- user_files
 >>> foobar
@@ -904,6 +935,7 @@ location /RequestDenied {
 --- request
 GET /foobar?baron=foobar
 --- error_code: 412
+
 === WL TEST 13: Whitelisting multiple rules in one WL.
 --- user_files
 >>> foobar
@@ -932,6 +964,7 @@ location /RequestDenied {
 --- request
 GET /?a=yesone&b=yestwo
 --- error_code: 412
+
 === WL TEST 14 : Whitelist on ARG_NAME.
 --- user_files
 >>> foobar
@@ -960,6 +993,7 @@ location /RequestDenied {
 --- request
 GET /?b=yestwo
 --- error_code: 200
+
 === WL TEST 14.1 : Whitelist on ARG_NAME.
 --- user_files
 >>> foobar
@@ -988,6 +1022,7 @@ location /RequestDenied {
 --- request
 GET /?b=yesone
 --- error_code: 412
+
 === WL TEST 15 : Whitelisting multiple rules in one WL.
 --- user_files
 >>> foobar
@@ -1017,6 +1052,7 @@ location /RequestDenied {
 --- request
 GET /?a=yesone&b=yestwo
 --- error_code: 200
+
 === WL TEST 16 : Whitelisting all rules on one arg (wl:0).
 --- user_files
 >>> foobar
@@ -1046,6 +1082,7 @@ location /RequestDenied {
 --- request
 GET /?a=yesoneyestwo
 --- error_code: 200
+
 === WL TEST 17 : Whitelisting all rules on one arg (wl:0) NOT.
 --- user_files
 >>> foobar
@@ -1103,6 +1140,7 @@ location /RequestDenied {
 POST /
 
 --- error_code: 412
+
 === WL TEST 18.1 : Whitelisting internal rule
 --- user_files
 >>> foobar
@@ -1132,6 +1170,7 @@ location /RequestDenied {
 POST /
 
 --- error_code: 200
+
 === WL TEST 19.0 : Rule in variable name
 --- user_files
 >>> foobar
@@ -1159,6 +1198,7 @@ location /RequestDenied {
 --- request
 GET /?a123a=foobar
 --- error_code: 412
+
 === WL TEST 19.1 : Rule in variable name (whitelisted)
 --- user_files
 >>> foobar
@@ -1187,6 +1227,7 @@ location /RequestDenied {
 --- request
 GET /?a123a=lol
 --- error_code: 200
+
 === WL TEST 20.0 : wl:0 in cookies (#405)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -1212,6 +1253,7 @@ Cookie: 123
 --- request
 GET /
 --- error_code: 412
+
 === WL TEST 20.1 : wl:0 in cookies (#405)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;
@@ -1237,6 +1279,7 @@ Cookie: 124
 --- request
 GET /
 --- error_code: 200
+
 === WL TEST 20.0 : wl:0 in cookies (#405)
 --- main_config
 load_module $TEST_NGINX_NAXSI_MODULE_SO;

--- a/unit-tests/tests/16rx_mz.t
+++ b/unit-tests/tests/16rx_mz.t
@@ -65,6 +65,7 @@ location /RequestDenied {
 --- request
 GET /buixor?bra=1999
 --- error_code: 412
+
 === RXWL TEST 1.2: simple wide regex ($args_var)
 --- user_files
 >>> buixor
@@ -177,6 +178,7 @@ location /RequestDenied {
 --- request
 GET /buixor?aablaa=1999
 --- error_code: 412
+
 === RXWL TEST 1.5: simple begin-restrictive regex ($args_var_x:^..)
 --- user_files
 >>> buixor
@@ -261,6 +263,7 @@ location /RequestDenied {
 --- request
 GET /buixor?ablaa=1999
 --- error_code: 412
+
 === RXWL TEST 1.8: simple full-restrictive regex ($args_var_x:^..$)
 --- user_files
 >>> buixor
@@ -289,6 +292,7 @@ location /RequestDenied {
 --- request
 GET /buixor?abla=1999
 --- error_code: 412
+
 === RXWL TEST 1.9: simple full-restrictive regex ($args_var_x:^..$)
 --- user_files
 >>> buixor
@@ -375,6 +379,7 @@ location /RequestDenied {
 --- request
 GET /foz?bla=1999
 --- error_code: 412
+
 === RXWL TEST 2.2: simple half-restrictive regex ($args_var|$url)
 --- user_files
 >>> foo
@@ -403,6 +408,7 @@ location /RequestDenied {
 --- request
 GET /foo?blaz=1999
 --- error_code: 412
+
 === RXWL TEST 3.0: simple wide regex (url|args|name)
 --- user_files
 >>> foo
@@ -517,6 +523,7 @@ location /RequestDenied {
 --- request
 GET /?foo_1999_inject=x
 --- error_code: 412
+
 === RXWL TEST 5.0: file ext ($URL|NAME) XXX
 --- user_files
 >>> foo
@@ -574,3 +581,25 @@ location /RequestDenied {
 --- request
 GET /?foo_1999_=ABCD
 --- error_code: 200
+
+
+=== RXWL TEST 7.0: ensure pipes are accepted in matchzone
+--- main_config
+load_module $TEST_NGINX_NAXSI_MODULE_SO;
+--- http_config
+include $TEST_NGINX_NAXSI_RULES;
+MainRule "rx:^a$" "msg:foobar test pattern" "mz:$URL_X:/poooel|$ARGS_VAR_X:^(a|b)$|NAME" "s:$XYZ:5" id:2001;
+
+--- config
+location / {
+    SecRulesEnabled;
+    DeniedUrl "/RequestDenied";
+    CheckRule "$XYZ >= 5" BLOCK;
+    return 200;
+}
+location /RequestDenied {
+    return 412;
+}
+--- request
+GET /poooel?a=abc&b=xyz
+--- error_code: 412


### PR DESCRIPTION
Using a matchzone like `"mz:$ARGS_VAR_X:^(a|b)$"` was making the regex seen like `^(a` instead of `^(a|b)$`.

Example rule:
```
MainRule "rx:^a$" "msg:foobar test pattern" "mz:$URL_X:/poooel|$ARGS_VAR_X:^(a|b)$|NAME" "s:$XYZ:5" id:2001;
```