### PR TITLE
naxsi_src/config: Set the correct variable to link to system libinjection

### DIFF
--- a/naxsi_src/config
+++ b/naxsi_src/config
@@ -49,7 +49,7 @@ if [ "$LIBINJECTION_FOUND" != "0" ]; then
 else
     echo "Using system libinjection"
     CFLAGS="$CFLAGS $LIBINJECTION_CFLAGS"
-    ngx_feature_libs="$LIBINJECTION_LIBS"
+    ngx_module_libs="$LIBINJECTION_LIBS"
 fi
 
 # NGINX module condfiguration.


### PR DESCRIPTION
This popped up as [bug 964736](https://bugs.gentoo.org/964736) on Gentoo Bugzilla. Basically, when modules want to link to external libraries, they should set `ngx_module_link` variable prior to calling `. auto/module`. `ngx_feature_libs` is for checking whether a header/function is present via `. auto/feature`.

As it is currently, if using system libinjection, naxsi doesn't correctly link to libinjection which, obviously, causes undefined symbols at runtime.